### PR TITLE
SRE-2386: use NEWest ARC

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: utility-staging-amd64
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   e2e-test:
-    runs-on: ubuntu-latest
+    runs-on: utility-staging-amd64
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: utility-staging-amd64
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
## Linear Ticket

[SRE-2386
](https://linear.app/ovice/issue/SRE-2386/migrate-github-actions-to-actions-runner-controller-staging-part-2)
## Overview
-  we are migrating all of our CI to selfhosted runner

## Areas to focus on
- use  utility-staging-amd64

## Summary by Sourcery

CI:
- Migrate CI workflows to use the 'utility-staging-amd64' self-hosted runner instead of 'ubuntu-latest'.