### PR TITLE
SRE-2386: use newest ARC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: utility-staging-amd64
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the CI workflow to run unit tests on the 'utility-staging-amd64' environment instead of 'ubuntu-latest'.